### PR TITLE
Add a link to Don't Panic

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     <h2><a href="https://www.youtube.com/watch?v=PAAkCSZUG1c&t=17m25s">Don't just check errors, handle them gracefully.</a></h2>
     <h2><a href="https://www.youtube.com/watch?v=PAAkCSZUG1c&t=18m09s">Design the architecture, name the components, document the details.</a></h2>
     <h2><a href="https://www.youtube.com/watch?v=PAAkCSZUG1c&t=19m07s">Documentation is for users.</a></h2>
-    <h2>Don't panic.</h2>
+    <h2><a href="https://github.com/golang/go/wiki/CodeReviewComments#dont-panic">Don't panic.</a></h2>
 
     <div class="footer">
         <p>Proverbs from <a href="https://twitter.com/rob_pike">@rob_pike</a>'s inspiring 


### PR DESCRIPTION
Adds a link to the "Don't Panic" proverb, adding more context. Unfortunately, it's not as approachable and entertaining as the original talk, but it provides a launching point for "use `panic()` infrequently", from two canonical sources: [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments#dont-panic), and indirectly [Effective Go](https://golang.org/doc/effective_go.html#errors).