### PR TITLE
add contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contribution guidelines
+
+Thank you for your interest in contributing to the Go Proverbs.
+
+Please be aware that the bar for addition is very high and to add a proverb one
+needs context that explains it.  The hope is that any further additions would
+be distillations of arguments about how to use the language.  Those arguments
+must be presented to support the nominated proverb.
+
+Because the bar for addition is very high and difficult to specify, additions
+to the list are unlikely to be accepted until there is another proverbs talk,
+or maybe a book, explaining and expanding on the originals plus the additions.

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         <a href="https://www.youtube.com/watch?v=PAAkCSZUG1c">talk at Gopherfest SV 2015 (video)</a>.</p>
         <p>The Gopher character is based on the Go mascot designed by Renée French and copyrighted under the
         Creative Commons Attribution 3.0 license.</p>
-	    <p>These proverbs are the basis of a <a href="https://www.youtube.com/watch?v=PAAkCSZUG1c">talk</a> by Rob Pike and the list may be updated when he next gives the talk.</p>
+        <p>These proverbs are the basis of a <a href="https://www.youtube.com/watch?v=PAAkCSZUG1c">talk</a> by Rob Pike and the list may be updated when he next gives the talk.</p>
         <p>Please open an <a href="https://github.com/go-proverbs/go-proverbs.github.io/issues">issue</a> to nominate a new proverb.</p>
     </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
         <p>The Gopher character is based on the Go mascot designed by Renée French and copyrighted under the
         Creative Commons Attribution 3.0 license.</p>
         <p>These proverbs are the basis of a <a href="https://www.youtube.com/watch?v=PAAkCSZUG1c">talk</a> by Rob Pike and the list may be updated when he next gives the talk.</p>
-        <p>Please open an <a href="https://github.com/go-proverbs/go-proverbs.github.io/issues">issue</a> to nominate a new proverb.</p>
+        <p>Please read the <a href="https://github.com/go-proverbs/go-proverbs.github.io/blob/master/CONTRIBUTING.md">contribution guidelines</a> before opening an <a href="https://github.com/go-proverbs/go-proverbs.github.io/issues">issue</a> to nominate a new proverb.</p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
This adds a `CONTRIBUTING.md` that GitHub will recognize and present to users when creating issues or PRs.  These contributing guidelines are based on a [statement][0] by Rob Pike.

[0]: https://github.com/go-proverbs/go-proverbs.github.io/issues/30#issuecomment-378082604