### PR TITLE
Update link to the new url for the Go wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <h3><a href="https://www.youtube.com/watch?v=PAAkCSZUG1c&t=17m25s">Don't just check errors, handle them gracefully.</a></h3>
     <h3><a href="https://www.youtube.com/watch?v=PAAkCSZUG1c&t=18m09s">Design the architecture, name the components, document the details.</a></h3>
     <h3><a href="https://www.youtube.com/watch?v=PAAkCSZUG1c&t=19m07s">Documentation is for users.</a></h3>
-    <h3><a href="https://github.com/golang/go/wiki/CodeReviewComments#dont-panic">Don't panic.</a></h3>
+    <h3><a href="https://go.dev/wiki/CodeReviewComments#dont-panic">Don't panic.</a></h3>
 
     <div class="footer">
         <p>Proverbs from <a href="https://twitter.com/rob_pike">@rob_pike</a>'s inspiring 


### PR DESCRIPTION
The github link just has a link now that tells users to go to this page.  Suggestion to just skip the middleman with this link