### PR TITLE
Correct Rob Pike attribution link to official Bluesky profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <h3><a href="https://go.dev/wiki/CodeReviewComments#dont-panic">Don't panic.</a></h3>
 
     <div class="footer">
-        <p>Proverbs from <a href="https://twitter.com/rob_pike">@rob_pike</a>'s inspiring 
+        <p>Proverbs from <a href="https://bsky.app/profile/robpike.io">@robpike.io</a>'s inspiring
         <a href="https://www.youtube.com/watch?v=PAAkCSZUG1c">talk at Gopherfest SV 2015 (video)</a>.</p>
         <p>The Gopher character is based on the Go mascot designed by Renée French and copyrighted under the
         Creative Commons Attribution 3.0 license.</p>


### PR DESCRIPTION
### Description

Replaces the previous Twitter link with [Rob Pike’s verified Bluesky profile](https://bsky.app/profile/robpike.io) so that the reference points to the correct official source.

### Reason

The [existing Twitter account](https://twitter.com/rob_pike) is inactive, unverified, and does not appear to be his official profile.